### PR TITLE
Improve fish ingredient filtering

### DIFF
--- a/bloodfood.py
+++ b/bloodfood.py
@@ -267,14 +267,20 @@ def dedup_rank(df: pd.DataFrame, include_tags: str = "", exclude_tags: str = "")
         return token in str(desc or "").lower()
 
     if include_tags.strip():
-        inc = [t.strip().lower() for t in include_tags.split(",") if t.strip()]
+        raw = [t.strip().lower() for t in include_tags.split(",") if t.strip()]
+        inc = []
+        for t in raw:
+            inc.extend(_DISLIKE_SYNONYMS.get(t, [t]))
         R = R[
             R.apply(lambda r: any(row_has_token(r.get("tags",""), t) or
                                   desc_has_keyword(r.get("Desc",""), t) for t in inc), axis=1)
         ]
 
     if exclude_tags.strip():
-        exc = [t.strip().lower() for t in exclude_tags.split(",") if t.strip()]
+        raw = [t.strip().lower() for t in exclude_tags.split(",") if t.strip()]
+        exc = []
+        for t in raw:
+            exc.extend(_DISLIKE_SYNONYMS.get(t, [t]))
         R = R[
             ~R.apply(lambda r: any(row_has_token(r.get("tags",""), t) or
                                    desc_has_keyword(r.get("Desc",""), t) for t in exc), axis=1)
@@ -688,19 +694,41 @@ _DIET_BLOCK = {
     "Vegetarian":   re.compile(r"\b(beef|pork|chicken|turkey|lamb|veal|fish|salmon|tuna|shrimp|oyster|clam|crab|lobster)\b", re.I),
     "Pescatarian":  re.compile(r"\b(beef|pork|chicken|turkey|lamb|veal)\b", re.I),
 }
+
+_DISLIKE_SYNONYMS = {
+    "fish": [
+        "fish","salmon","tuna","sardine","sardines","anchovy","anchovies",
+        "mackerel","herring","trout","cod","halibut","tilapia","seafood"
+    ]
+}
 def apply_hard_filters(df: pd.DataFrame, diet_pattern: str, exclusions: list[str], dislikes: str) -> pd.DataFrame:
     R = df.copy()
     desc = R["Desc"].fillna("").astype(str)
+    tags = R.get("tags", "").fillna("").astype(str)
     block_re = _DIET_BLOCK.get(diet_pattern)
-    if block_re is not None: R = R[~desc.str.contains(block_re)]
+    if block_re is not None:
+        mask = desc.str.contains(block_re)
+        R = R[~mask]
+        desc = R["Desc"].fillna("").astype(str)
+        tags = R.get("tags", "").fillna("").astype(str)
     for ex in exclusions:
         ex_re = _EXCL_PATTERNS.get(ex)
-        if ex_re is not None: R = R[~desc.str.contains(ex_re)]
+        if ex_re is not None:
+            mask = desc.str.contains(ex_re)
+            R = R[~mask]
+            desc = R["Desc"].fillna("").astype(str)
+            tags = R.get("tags", "").fillna("").astype(str)
     if dislikes.strip():
-        bads = [re.escape(x.strip()) for x in dislikes.split(",") if x.strip()]
-        if bads:
-            bad_re = re.compile(r"(" + "|".join(bads) + r")", re.I)
-            R = R[~desc.str.contains(bad_re)]
+        raw = [x.strip().lower() for x in dislikes.split(",") if x.strip()]
+        tokens = []
+        for t in raw:
+            tokens.extend(_DISLIKE_SYNONYMS.get(t, [t]))
+        if tokens:
+            bads = [re.escape(x) for x in tokens]
+            bad_re = re.compile(r"(?:" + "|".join(bads) + r")", re.I)
+            mask_desc = desc.str.contains(bad_re)
+            mask_tags = tags.str.contains(bad_re)
+            R = R[~(mask_desc | mask_tags)]
     return R
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Broaden dislike filtering to examine both descriptions and tags with synonym expansion so excluding "fish" also drops cod, salmon, etc.
- Pass soft-goal sliders into the preference scorer so changing sugar, sodium, or protein weights updates rankings.

## Testing
- `python -m py_compile app.py bloodfood.py`


------
https://chatgpt.com/codex/tasks/task_e_68adee625bd08330b36070c66cbaef20