### PR TITLE
Persist parsed labs across reruns

### DIFF
--- a/bloodfood.py
+++ b/bloodfood.py
@@ -753,7 +753,10 @@ schema   = load_lab_schema()
 catalog  = load_catalog()
 fnd_nutr = load_fnd_features()
 
-parsed_df = None
+if "parsed_df" not in st.session_state:
+    st.session_state["parsed_df"] = None
+
+parsed_df = st.session_state["parsed_df"]
 if run_clicked:
     labs_dict = {}
     try:
@@ -784,6 +787,7 @@ if run_clicked:
             "wbc": labs_dict.get("wbc"),
         }
         parsed_df = pd.DataFrame([mapped])
+        st.session_state["parsed_df"] = parsed_df
 
 # ---- Labs & BioAge
 st.subheader("Parsed labs & BioAge")


### PR DESCRIPTION
## Summary
- Preserve parsed lab results in `st.session_state` so model blend sliders update recommendations

## Testing
- `pytest`
- `python -m py_compile bloodfood.py`


------
https://chatgpt.com/codex/tasks/task_e_68b04eadc7d0833091ffcefd8bc059db